### PR TITLE
Small fixes in LCC and BGTBuildingFuser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,9 @@ lazrs==0.3.1
 matplotlib==3.3.4
 numba==0.53.1
 numpy==1.20.2
-pyclipper==1.2.1
 laspy==2.0.2
 shapely==1.7.1
-scikit-learn=0.24.2
+scikit-learn==0.24.2
 scipy==1.6.2
 tifffile==2021.6.14
 tqdm==4.61.0

--- a/src/fusion/bgt_fuser.py
+++ b/src/fusion/bgt_fuser.py
@@ -8,10 +8,12 @@ import logging
 from pathlib import Path
 from sklearn.cluster import DBSCAN
 from scipy.stats import binned_statistic_2d
+from shapely.geometry import Polygon
+from shapely.ops import cascaded_union
 from abc import ABC, abstractmethod
 
 from ..abstract_processor import AbstractProcessor
-from ..utils.clip_utils import poly_offset, poly_clip, cylinder_clip, box_clip
+from ..utils import clip_utils
 from ..utils.las_utils import get_bbox_from_tile_code
 from ..utils.interpolation import FastGridInterpolator
 from ..utils.labels import Labels
@@ -136,7 +138,7 @@ class BGTBuildingFuser(BGTFuser):
         # TODO will this speedup the process?
         self.bgt_df.sort_values(by=['x_max', 'y_min'], inplace=True)
 
-    def _filter_tile(self, tilecode):
+    def _filter_tile(self, tilecode, merge=True):
         """
         Return a list of polygons representing each of the buildings found in
         the area represented by the given CycloMedia tile-code.
@@ -145,10 +147,15 @@ class BGTBuildingFuser(BGTFuser):
             get_bbox_from_tile_code(tilecode, padding=self.padding)
         df = self.bgt_df.query('(x_min < @bx_max) & (x_max > @bx_min)' +
                                ' & (y_min < @by_max) & (y_max > @by_min)')
-        building_polygons = [ast.literal_eval(poly)
-                             for poly in df.Polygon.values]
-
-        return building_polygons
+        buildings = [ast.literal_eval(poly) for poly in df.Polygon.values]
+        if merge:
+            poly_offset = list(cascaded_union([Polygon(bld).buffer(1)
+                                               for bld in buildings]))
+        else:
+            poly_offset = [Polygon(bld).buffer(1) for bld in buildings]
+        poly_valid = [poly.exterior.coords for poly in poly_offset
+                      if len(poly.exterior.coords) > 1]
+        return poly_valid
 
     def get_label_mask(self, points, labels, mask, tilecode):
         """
@@ -182,8 +189,7 @@ class BGTBuildingFuser(BGTFuser):
         for polygon in building_polygons:
             # TODO if there are multiple buildings we could mask the points
             # iteratively to ignore points already labelled.
-            building_with_offset = poly_offset(polygon, self.building_offset)
-            building_points = poly_clip(points[mask, :], building_with_offset)
+            building_points = clip_utils.poly_clip(points[mask, :], polygon)
             building_mask = building_mask | building_points
 
         logger.debug(f'{len(building_polygons)} building polygons labelled.')
@@ -301,9 +307,10 @@ class BGTPointFuser(BGTFuser):
 
         For a description of parameters see "Notes" above.
         """
-        search_ids = np.where(cylinder_clip(points, point, search_radius,
-                                            bottom=plane_height-plane_buffer,
-                                            top=plane_height+plane_buffer))[0]
+        search_ids = np.where(clip_utils.cylinder_clip(
+                                points, point, search_radius,
+                                bottom=plane_height-plane_buffer,
+                                top=plane_height+plane_buffer))[0]
         if len(search_ids) < min_points:
             return np.empty((0, 3))
         # Cluster the potential seed points.
@@ -358,9 +365,9 @@ class BGTPointFuser(BGTFuser):
             # Define the "box" within which to search for candidates.
             search_box = (obj[0]-search_pad, obj[1]-search_pad,
                           obj[0]+search_pad, obj[1]+search_pad)
-            box_ids = np.where(box_clip(points, search_box,
-                                        bottom=ground_z+z_min,
-                                        top=ground_z+z_max))[0]
+            box_ids = np.where(clip_utils.box_clip(points, search_box,
+                                                   bottom=ground_z+z_min,
+                                                   top=ground_z+z_max))[0]
             if len(box_ids) == 0:
                 # Empty search box, no match.
                 matches[obj] = None
@@ -463,9 +470,10 @@ class BGTPointFuser(BGTFuser):
             # Label a cylinder based on the seed cluster.
             top_height = (fast_z(np.array([seed[0:2]]))
                           + self.params['label_height'])
-            clip_mask = cylinder_clip(points[mask], np.array(seed[0:2]),
-                                      self.params['r_mult']*seed[2],
-                                      top=top_height)
+            clip_mask = clip_utils.cylinder_clip(
+                                        points[mask], np.array(seed[0:2]),
+                                        self.params['r_mult']*seed[2],
+                                        top=top_height)
             label_mask[mask] = label_mask[mask] | clip_mask
 
         match_str = ', '.join([f'{obj}->{cand}'

--- a/src/fusion/car_fuser.py
+++ b/src/fusion/car_fuser.py
@@ -71,13 +71,11 @@ class CarFuser(BGTFuser):
         car_mask = np.zeros(len(points), dtype=bool)
         car_count = 0
 
-        cc_labels, counts = np.unique(point_components,
-                                      return_counts=True)
+        cc_labels = np.unique(point_components)
 
-        # TODO: remove when LCC is fixed
-        cc_labels_filtered = cc_labels[counts >= self.min_component_size]
+        cc_labels = set(cc_labels).difference((-1,))
 
-        for cc in cc_labels_filtered:
+        for cc in cc_labels:
             # select points that belong to the cluster
             cc_mask = (point_components == cc)
 

--- a/src/fusion/noise_filter.py
+++ b/src/fusion/noise_filter.py
@@ -65,23 +65,22 @@ class NoiseFilter(AbstractProcessor):
         lcc = LabelConnectedComp(self.label, octree_level=self.octree_level,
                                  min_component_size=self.min_component_size)
         point_components = lcc.get_components(points[mask])
-
-        cc_labels, counts = np.unique(point_components,
-                                      return_counts=True)
-
-        cc_labels_filtered = cc_labels[counts < self.min_component_size]
-        logger.debug(f'Found {len(cc_labels_filtered)} clusters of ' +
-                     f'<{self.min_component_size} points.')
+        cc_mask = point_components == -1
+        logger.debug(f'Found {np.count_nonzero(cc_mask)} noise points in '
+                     + f'clusters <{self.min_component_size} points.')
 
         # Get the interpolated ground points of the tile
         ahn_tile = self.ahn_reader.filter_tile(tilecode)
         surface = ahn_tile['ground_surface']
         fast_z = FastGridInterpolator(ahn_tile['x'], ahn_tile['y'], surface)
         target_z = fast_z(points[mask, :])
+        ground_mask = (points[mask, 2] - target_z) < -self.epsilon
+        diff = ground_mask & ~cc_mask
+        logger.debug(f'Found {np.count_nonzero(diff)} noise points '
+                     + 'below ground level.')
 
         label_mask = np.zeros((len(points),), dtype=bool)
         # Label points below ground and points in small components.
-        label_mask[mask] = (np.in1d(point_components, cc_labels_filtered)
-                            | ((points[mask, 2] - target_z) < -self.epsilon))
+        label_mask[mask] = cc_mask | ground_mask
 
         return label_mask

--- a/src/utils/clip_utils.py
+++ b/src/utils/clip_utils.py
@@ -10,9 +10,12 @@ https://github.com/sasamil/PointInPolygon_Py
 import numpy as np
 from numba import jit
 import numba
-import pyclipper
+import logging
+from shapely.geometry import Polygon
 
 from ..utils import math_utils
+
+logger = logging.getLogger(__name__)
 
 
 @jit(nopython=True)
@@ -205,6 +208,8 @@ def poly_clip(points, poly):
     A boolean mask with True entries for all points within the polygon.
     """
     # Convert to numpy to work with numba jit in nopython mode.
+    if poly[0] != poly[-1]:
+        logger.warning('Polygon should be a closed ring!')
     np_poly = np.array(poly)
 
     # Clip to bounding box
@@ -249,29 +254,19 @@ def poly_box_clip(points, poly, bottom=-np.inf, top=np.inf):
 
 def poly_offset(polygon, offset_meter):
     """
-    Calculate coordinates of radius/offset around a polygon.
+    Inflate or deflate a polygon.
 
     Parameters
     ----------
     polygon : list
         One polygon in list format
     offset_meter : int
-        Offset in meters (deflation, minus value, has bugs)
+        Offset in meters (negative value means deflation)
 
     Returns
     -------
     list
         Inflated polygon in a 1D list
     """
-    clipper_offset = pyclipper.PyclipperOffset()
-    coordinates_scaled = pyclipper.scale_to_clipper(polygon)
-
-    clipper_offset.AddPath(coordinates_scaled, pyclipper.JT_SQUARE,
-                           pyclipper.ET_CLOSEDPOLYGON)
-
-    new_coordinates = clipper_offset.Execute(pyclipper
-                                             .scale_to_clipper(offset_meter))
-
-    polygon_offset = pyclipper.scale_from_clipper(new_coordinates)[0]
-
-    return polygon_offset
+    shpl_poly = Polygon(polygon).buffer(offset_meter)
+    return shpl_poly.exterior.coords


### PR DESCRIPTION
* LabelConnectedComp now labels all components below min_component_size as -1.

* The method poly_offset() is now based on shapely instead of pyclipper; this fixes a bug that caused inflated polygons not to be closed rings.

* BGTBuildingFuser now first merges polygons before clipping, this gives a small decrease in computation time.

* fixes #20 